### PR TITLE
Fix di compile

### DIFF
--- a/Controller/Adminhtml/Mail/SendPost.php
+++ b/Controller/Adminhtml/Mail/SendPost.php
@@ -30,20 +30,18 @@ class SendPost extends \Shockwavemk\Mail\Base\Controller\Adminhtml\Mail
      * @param StoreManagerInterface $storeManager
      * @param TransportBuilder $transportBuilder
      * @param Customer $customer
-     * @param \Magento\Framework\ObjectManagerInterface $manager
      */
     public function __construct(
         Context $context,
         StoreManagerInterface $storeManager,
         TransportBuilder $transportBuilder,
-        Customer $customer,
-        \Magento\Framework\ObjectManagerInterface $manager
+        Customer $customer
     )
     {
         $this->transportBuilder = $transportBuilder;
         $this->storeManager = $storeManager;
         $this->customer = $customer;
-        $this->manager = $manager;
+        $this->manager = $context->getObjectManager();
 
         parent::__construct($context);
     }

--- a/Model/Transports/DebugTransport.php
+++ b/Model/Transports/DebugTransport.php
@@ -6,6 +6,8 @@
 
 namespace Shockwavemk\Mail\Model\Transports;
 
+use Shockwavemk\Mail\Base\Model\Transports\Base;
+
 class DebugTransport extends Base implements \Magento\Framework\Mail\TransportInterface
 {
     /**


### PR DESCRIPTION
While running `bin/magenti setup:di:compile` I have got 2 errors:

```
Fatal error:  Class 'Shockwavemk\Mail\Model\Transports\Base' not found in /var/www/html/vendor/shockwavemk/magento2-module-mail/Model/Transports/DebugTransport.php on line 9
```

and

```
Errors during compilation:
    Shockwavemk\Mail\Base\Controller\Adminhtml\Mail\SendPost
        Incorrect dependency in class Shockwavemk\Mail\Base\Controller\Adminhtml\Mail\SendPost in /var/www/html/vendor/shockwavemk/magento2-module-mail/Controller/Adminhtml/Mail/SendPost.php
\Magento\Framework\ObjectManagerInterface already exists in context object
Total Errors Count: 1
```

These are now fixed.
